### PR TITLE
fix:missing swaps

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ processor.run(new TypeormDatabase({ supportHotBlocks: true }), async (ctx) => {
         //process log data
         let poolData = getPoolData(log);
         poolsData.push(poolData);
+        factoryPools.add(poolData.id);
       }
       if (
         log.topics[0] == poolAbi.events.Swap.topic &&
@@ -90,7 +91,6 @@ async function savePools(ctx: Context, poolsData: PoolData[]) {
       token1: data.token1,
     });
     pools.push(pool);
-    factoryPools.add(data.id);
   }
   await ctx.store.save(pools);
 }


### PR DESCRIPTION
I was building a personal project using this as a template and realized that some swaps were missing.

This was happening because swaps from a pool were being read before the pool data itself is saved and added to set in memory. Pool data should be saved in the memory as soon as it is seen or else it will miss the swaps in the same batch. Changed the code accordingly.